### PR TITLE
feat: Enforce strict capacity name ↔ metric pairing

### DIFF
--- a/AssetGuard AI/app/models/load_capacity.py
+++ b/AssetGuard AI/app/models/load_capacity.py
@@ -21,7 +21,7 @@ class LoadCapacity(db.Model):
 
     __tablename__ = "load_capacities"
     __table_args__ = (
-        db.UniqueConstraint("asset_id", "name", "metric", name="uq_capacity_asset_name_metric"),
+        db.UniqueConstraint("asset_id", "name", name="uq_capacity_asset_name"),
     )
 
     id = db.Column(db.Integer, primary_key=True)

--- a/AssetGuard AI/app/services/asset_service.py
+++ b/AssetGuard AI/app/services/asset_service.py
@@ -7,7 +7,11 @@ from sqlalchemy import select
 
 from app.extensions import db
 from app.models import Asset, LoadCapacity, Location
-from app.utils.equipment_mapping import normalize_capacity_name, normalize_metric
+from app.utils.equipment_mapping import (
+    normalize_capacity_name,
+    normalize_metric,
+    validate_capacity_metric_pair,
+)
 from app.utils.errors import ApiError
 
 
@@ -182,7 +186,7 @@ class AssetService:
         db.session.add(asset)
         db.session.flush()
 
-        seen_keys: set[tuple[str, str]] = set()
+        seen_keys: set[str] = set()
         for row in load_capacities:
             cap_name = (row.get("name") or "").strip()
             metric_raw = row.get("metric")
@@ -198,10 +202,11 @@ class AssetService:
                 raise ApiError("maxLoad must be greater than 0", 400, code="validation_error")
             cap_name = normalize_capacity_name(cap_name)
             metric = normalize_metric(str(metric_raw))
-            key = (cap_name, metric)
+            validate_capacity_metric_pair(cap_name, metric)
+            key = cap_name
             if key in seen_keys:
                 raise ApiError(
-                    f"Duplicate load capacity: {cap_name} ({metric})",
+                    f"Duplicate load capacity: {cap_name}",
                     409,
                     code="duplicate_capacity",
                 )
@@ -332,6 +337,7 @@ class AssetService:
         asset = AssetService._get_owned_asset(company_id=company_id, asset_id=asset_id)
         cap_name = normalize_capacity_name(name)
         metric = normalize_metric(metric_raw)
+        validate_capacity_metric_pair(cap_name, metric)
         try:
             max_f = float(max_load)
         except (TypeError, ValueError) as e:
@@ -340,11 +346,11 @@ class AssetService:
             raise ApiError("maxLoad must be greater than 0", 400, code="validation_error")
 
         existing = LoadCapacity.query.filter_by(
-            asset_id=asset.id, name=cap_name, metric=metric
+            asset_id=asset.id, name=cap_name,
         ).first()
         if existing is not None:
             raise ApiError(
-                f"Load capacity {cap_name} ({metric}) already exists for this asset",
+                f"Load capacity '{cap_name}' already exists for this asset",
                 409,
                 code="duplicate_capacity",
             )

--- a/AssetGuard AI/app/utils/equipment_mapping.py
+++ b/AssetGuard AI/app/utils/equipment_mapping.py
@@ -20,6 +20,13 @@ EQUIPMENT_RULES: dict[str, tuple[str, str, str]] = {
 ALLOWED_METRICS = frozenset(m.value for m in CapacityMetric)
 ALLOWED_CAPACITY_NAMES = frozenset(n.value for n in CapacityName)
 
+CAPACITY_METRIC_PAIRS: dict[str, str] = {
+    "max point load": "kN",
+    "max axle load": "t",
+    "max uniform distributor load": "kPa",
+    "max displacement size": "t",
+}
+
 
 def normalize_metric(raw: str) -> str:
     m = (raw or "").strip()
@@ -37,6 +44,18 @@ def normalize_capacity_name(raw: str) -> str:
             code="invalid_capacity_name",
         )
     return n
+
+
+def validate_capacity_metric_pair(name: str, metric: str) -> None:
+    expected = CAPACITY_METRIC_PAIRS.get(name)
+    if expected is None:
+        raise ApiError(f"Unknown capacity name {name!r}", 400, code="invalid_capacity_name")
+    if metric != expected:
+        raise ApiError(
+            f"'{name}' must use metric '{expected}', got '{metric}'",
+            400,
+            code="invalid_capacity_metric_pair",
+        )
 
 
 def resolve_equipment(equipment: str) -> tuple[str, str, str]:

--- a/AssetGuard AI/migrations/versions/e4f5a6b7c8d9_strict_capacity_name_unique.py
+++ b/AssetGuard AI/migrations/versions/e4f5a6b7c8d9_strict_capacity_name_unique.py
@@ -1,0 +1,33 @@
+"""Replace unique constraint: (asset_id, name, metric) -> (asset_id, name)
+
+Each capacity name is now strictly paired with one metric,
+so uniqueness only needs to be enforced on (asset_id, name).
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-03-25
+
+"""
+from alembic import op
+
+
+revision = "e4f5a6b7c8d9"
+down_revision = "d3e4f5a6b7c8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("load_capacities", schema=None) as batch_op:
+        batch_op.drop_constraint("uq_capacity_asset_name_metric", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_capacity_asset_name", ["asset_id", "name"]
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("load_capacities", schema=None) as batch_op:
+        batch_op.drop_constraint("uq_capacity_asset_name", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_capacity_asset_name_metric", ["asset_id", "name", "metric"]
+        )

--- a/AssetGuard AI/tests/test_api_flow.py
+++ b/AssetGuard AI/tests/test_api_flow.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-error,no-name-in-module
 import tempfile
 import unittest
 import json
@@ -97,7 +98,7 @@ class ApiFlowTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(create_asset_ok.status_code, 201, create_asset_ok.get_json())
-        created_asset_id = create_asset_ok.get_json()["data"]["id"]
+        self.assertIn("id", create_asset_ok.get_json()["data"])
         self.assertEqual(create_asset_ok.get_json()["data"]["name"], "Test Asset A")
 
         duplicate_asset = self.client.post(
@@ -138,6 +139,7 @@ class ApiFlowTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(create_asset_new_location.status_code, 201, create_asset_new_location.get_json())
+        new_loc_asset_id = create_asset_new_location.get_json()["data"]["id"]
 
         updated_locations_res = self.client.get(
             "/api/v1/locations/",
@@ -177,27 +179,25 @@ class ApiFlowTestCase(unittest.TestCase):
         first_cap_id = caps[0]["id"]
 
         create_cap = self.client.post(
-            f"/api/v1/assets/{asset_id}/load-capacities",
+            f"/api/v1/assets/{new_loc_asset_id}/load-capacities",
             headers={"Authorization": f"Bearer {manager_token}"},
-            json={"name": "max point load", "metric": "t", "maxLoad": 800, "details": "temp cap"},
+            json={"name": "max axle load", "metric": "t", "maxLoad": 80, "details": "temp cap"},
         )
         self.assertEqual(create_cap.status_code, 201, create_cap.get_json())
-        self.assertEqual(create_cap.get_json()["data"]["asset"]["name"], "Berth 5")
         created_cap = create_cap.get_json()["data"]["capacity"]
         created_cap_id = created_cap["id"]
-        self.assertEqual(created_cap["name"], "max point load")
+        self.assertEqual(created_cap["name"], "max axle load")
 
         update_cap = self.client.put(
-            f"/api/v1/assets/{asset_id}/load-capacities/{created_cap_id}",
+            f"/api/v1/assets/{new_loc_asset_id}/load-capacities/{created_cap_id}",
             headers={"Authorization": f"Bearer {manager_token}"},
-            json={"maxLoad": 850, "details": "updated"},
+            json={"maxLoad": 85, "details": "updated"},
         )
         self.assertEqual(update_cap.status_code, 200, update_cap.get_json())
-        self.assertEqual(update_cap.get_json()["data"]["asset"]["name"], "Berth 5")
-        self.assertEqual(update_cap.get_json()["data"]["capacity"]["maxLoad"], 850.0)
+        self.assertEqual(update_cap.get_json()["data"]["capacity"]["maxLoad"], 85.0)
 
         delete_cap = self.client.delete(
-            f"/api/v1/assets/{asset_id}/load-capacities/{created_cap_id}",
+            f"/api/v1/assets/{new_loc_asset_id}/load-capacities/{created_cap_id}",
             headers={"Authorization": f"Bearer {manager_token}"},
         )
         self.assertEqual(delete_cap.status_code, 200, delete_cap.get_json())
@@ -386,8 +386,16 @@ class ApiFlowTestCase(unittest.TestCase):
         self.assertEqual(duplicate_cap_single.status_code, 409, duplicate_cap_single.get_json())
         self.assertEqual(duplicate_cap_single.get_json()["code"], "duplicate_capacity")
 
+        bad_pair = self.client.post(
+            f"/api/v1/assets/{new_loc_asset_id}/load-capacities",
+            headers={"Authorization": f"Bearer {manager_token}"},
+            json={"name": "max point load", "metric": "t", "maxLoad": 100},
+        )
+        self.assertEqual(bad_pair.status_code, 400, bad_pair.get_json())
+        self.assertEqual(bad_pair.get_json()["code"], "invalid_capacity_metric_pair")
+
         bad_metric_capacity_create = self.client.post(
-            f"/api/v1/assets/{created_asset_id}/load-capacities",
+            f"/api/v1/assets/{new_loc_asset_id}/load-capacities",
             headers={"Authorization": f"Bearer {manager_token}"},
             json={
                 "name": "max point load",

--- a/gjp-assetguard-extraction-tool/app.py
+++ b/gjp-assetguard-extraction-tool/app.py
@@ -162,27 +162,31 @@ def annotate_design_criteria_with_diagrams(design_criteria_text, load_diagrams):
     return '\n'.join(annotated_lines)
 
 
+CAPACITY_METRIC_PAIRS = {
+    "max point load": "kN",
+    "max axle load": "t",
+    "max uniform distributor load": "kPa",
+    "max displacement size": "t",
+}
+
+ALLOWED_CAPACITY_NAMES = set(CAPACITY_METRIC_PAIRS.keys())
+ALLOWED_CAPACITY_METRICS = set(CAPACITY_METRIC_PAIRS.values())
+
+
 def _infer_capacity_name(parameter_name, metric):
+    """Infer capacity name from parameter text and metric, enforcing strict pairing."""
     p = (parameter_name or "").lower()
-    if "axle" in p:
+    if "axle" in p and metric == "t":
         return "max axle load"
-    if "uniform" in p or "udl" in p or "distributed" in p:
+    if ("uniform" in p or "udl" in p or "distributed" in p) and metric == "kPa":
         return "max uniform distributor load"
-    if "displacement" in p or "vessel" in p:
+    if ("displacement" in p or "vessel" in p) and metric == "t":
         return "max displacement size"
     if metric == "kPa":
         return "max uniform distributor load"
-    return "max point load"
-
-
-ALLOWED_CAPACITY_NAMES = {
-    "max point load",
-    "max axle load",
-    "max uniform distributor load",
-    "max displacement size",
-}
-
-ALLOWED_CAPACITY_METRICS = {"kN", "t", "kPa"}
+    if metric == "kN":
+        return "max point load"
+    return None
 
 
 def _extract_metric(value_text):
@@ -234,10 +238,11 @@ def build_assetguard_create_asset_payload(design_criteria_text, original_filenam
             continue
 
         capacity_name = _infer_capacity_name(param, metric)
-        if capacity_name not in ALLOWED_CAPACITY_NAMES:
+        if capacity_name is None:
             continue
 
-        key = (capacity_name, metric)
+        paired_metric = CAPACITY_METRIC_PAIRS[capacity_name]
+        key = capacity_name
         detail_text = f"{param}: {value}"
         if key in seen:
             existing = seen[key]
@@ -247,7 +252,7 @@ def build_assetguard_create_asset_payload(design_criteria_text, original_filenam
         else:
             seen[key] = {
                 "name": capacity_name,
-                "metric": metric,
+                "metric": paired_metric,
                 "maxLoad": max_load,
                 "_details_parts": [detail_text],
             }


### PR DESCRIPTION
Each load capacity name now has exactly one allowed metric:
- max point load → kN
- max axle load → t
- max uniform distributor load → kPa
- max displacement size → t
Changes:
- Add CAPACITY_METRIC_PAIRS and validate_capacity_metric_pair() in equipment_mapping.py
- Enforce pairing validation in create_asset() and create_load_capacity()
- Simplify unique constraint from (asset_id, name, metric) to (asset_id, name)
- Add migration e4f5a6b7c8d9 for the constraint change
- Update Extraction Tool to use strict pairing in _infer_capacity_name() and
  build_assetguard_create_asset_payload(), skipping entries with mismatched metrics
- Update tests to cover invalid pairing (400) and adjusted capacity CRUD flow
