### PR TITLE
feat(dev-startup): launch extraction service with backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,20 @@ git push -u origin <your-branch-name>
 
 ### Requirements
 
-- Python 3.11+
+- Python 3.11+ (on your `PATH` as `python` / `python3`)
 - Node.js and npm
-- For **macOS Apple Silicon only**: `uv` package manager (see [Initialise and run](#initialise-and-run) section)
+- For **macOS Apple Silicon** (optional): install `uv` if you use [`start-dev-uv.sh`](#initialise-and-run) — not required for `./start-dev.sh`
+
+**You do not need to create or activate a virtual environment before the first run** if you use the repository root bootstrap scripts (`start-dev.bat`, `start-dev.sh`, or `start-dev-uv.sh`). They create and use `AssetGuard-AI/.venv`, install backend dependencies, apply migrations, conditionally run `seed`, then start the dev servers.  
+Only use the [manual venv steps](#optional-manual-virtual-environment-backend-only) below if you are **not** using those scripts and intend to run `flask` commands yourself.
 
 ---
 
 ## 1. Main Backend — `AssetGuard-AI`
 
-### Set up the virtual environment
+### Optional: manual virtual environment (backend-only)
+
+Skip this subsection when using `start-dev.bat`, `start-dev.sh`, or `start-dev-uv.sh`.
 
 **Windows (PowerShell):**
 
@@ -135,8 +140,7 @@ AI_JSON_UPLOADS_DIR=/path/to/gjp-assetguard-extraction-tool/uploads
 
 ### Initialise and run
 
-Recommended: use the workspace bootstrap scripts from the repository root.  
-These scripts start both backend and frontend.
+Recommended: from the **repository root**, run a single bootstrap script — **no manual venv setup required** for that path.
 
 **Windows (PowerShell):**
 
@@ -167,7 +171,12 @@ chmod +x ./start-dev.sh
 ./start-dev.sh
 ```
 
-Bootstrap behavior:
+What the scripts start:
+
+- **`start-dev.bat` / `start-dev.sh`**: backend (`http://127.0.0.1:5000`), frontend (Vite — URL printed in that process), and **optionally** the AI extraction tool under `gjp-assetguard-extraction-tool` on **`http://127.0.0.1:5001`** when that folder exists. Backend and frontend always start; extraction tool bootstrap or runtime failures are isolated and **do not** stop the backend or frontend.
+- **`start-dev-uv.sh`**: backend and frontend only (uses `uv`/`uv pip` under `AssetGuard-AI/.venv`; does not launch the extraction tool).
+
+Bootstrap behavior (all three scripts, for the backend):
 
 - Always runs `flask db upgrade` first
 - Runs `flask seed` when either:
@@ -177,7 +186,7 @@ Bootstrap behavior:
 
 **Note on package managers**: The `start-dev-uv.sh` script uses `uv` for faster dependency installation on macOS Apple Silicon, while `start-dev.sh` uses the standard `pip` approach.
 
-Manual backend-only alternative:
+Manual backend-only alternative (**requires** an environment where backend dependencies are already installed — typically after [manual venv](#optional-manual-virtual-environment-backend-only)):
 
 ```bash
 # In AssetGuard-AI/

--- a/start-dev-uv.sh
+++ b/start-dev-uv.sh
@@ -17,6 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR"
 BACKEND_DIR="$REPO_ROOT/AssetGuard-AI"
 FRONTEND_DIR="$REPO_ROOT/assetguard-ui"
+EXTRACTION_DIR="$REPO_ROOT/gjp-assetguard-extraction-tool"
 
 if [[ ! -d "$BACKEND_DIR" ]]; then
   echo "Backend folder not found: $BACKEND_DIR" >&2
@@ -114,13 +115,74 @@ npm run dev &
 FRONTEND_PID=$!
 echo "Frontend started (PID: $FRONTEND_PID)"
 
+EXTRACTION_PID=""
+if [[ -d "$EXTRACTION_DIR" ]]; then
+  (
+    set +e
+    set +u
+    cd "$EXTRACTION_DIR" || {
+      echo "[Warning] Extraction tool: could not cd to $EXTRACTION_DIR. Skipping." >&2
+      exit 0
+    }
+
+    echo "== AssetGuard Extraction Tool Bootstrap =="
+
+    if [[ ! -d ".venv" ]]; then
+      echo "[First-time] No extraction-tool virtual environment found. Creating .venv ..."
+      if ! python3 -m venv .venv; then
+        echo "[Warning] Extraction tool: venv creation failed. Skipping extraction server." >&2
+        exit 0
+      fi
+    fi
+
+    if [[ -f ".venv/bin/activate" ]]; then
+      source .venv/bin/activate
+      echo "Virtual environment activated: .venv"
+    else
+      echo "[Warning] Extraction tool: Failed to activate virtual environment. Skipping." >&2
+      exit 0
+    fi
+
+    EXTRACTION_PY="$(pwd)/.venv/bin/python"
+    echo "Python executable path: $EXTRACTION_PY"
+
+    if ! "$EXTRACTION_PY" -m pip install --upgrade pip; then
+      echo "[Warning] Extraction tool: pip upgrade failed. Skipping extraction server." >&2
+      exit 0
+    fi
+
+    echo "Ensuring extraction-tool dependencies from requirements.txt ..."
+    if ! "$EXTRACTION_PY" -m pip install -r requirements.txt; then
+      echo "[Warning] Extraction tool: pip install failed. Skipping extraction server." >&2
+      exit 0
+    fi
+
+    if [[ ! -f ".env" ]]; then
+      echo "[Warning] .env file not found in extraction tool folder. Some features may not work."
+    fi
+
+    echo "Starting extraction tool server on http://127.0.0.1:5001 ..."
+    exec "$EXTRACTION_PY" -m flask --app app.py run --port 5001
+  ) &
+  EXTRACTION_PID=$!
+  echo "Extraction tool started (PID: $EXTRACTION_PID)"
+else
+  echo "[Warning] Extraction tool folder not found; skipping extraction server: $EXTRACTION_DIR" >&2
+fi
+
 cleanup() {
   echo ""
-  echo "Stopping backend and frontend..."
+  echo "Stopping backend, frontend, and extraction tool..."
   kill "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+  if [[ -n "${EXTRACTION_PID:-}" ]]; then
+    kill "$EXTRACTION_PID" 2>/dev/null || true
+  fi
   cd "$BACKEND_DIR"
   deactivate 2>/dev/null || true
 }
 
 trap cleanup INT TERM
 wait "$BACKEND_PID" "$FRONTEND_PID"
+if [[ -n "${EXTRACTION_PID:-}" ]]; then
+  wait "$EXTRACTION_PID" || true
+fi

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -13,10 +13,6 @@ if (-not (Test-Path $frontendDir)) {
     throw "Frontend folder not found: $frontendDir"
 }
 
-if (-not (Test-Path $extractionDir)) {
-    throw "Extraction tool folder not found: $extractionDir"
-}
-
 $backendCmdTemplate = @'
 Set-Location '__BACKEND_DIR__'
 
@@ -89,6 +85,8 @@ npm run dev
 '@
 
 $extractionCmdTemplate = @'
+# Extraction tool runs in its own window; failures here must NOT affect backend/frontend.
+try {
 Set-Location '__EXTRACTION_DIR__'
 
 Write-Host '== AssetGuard Extraction Tool Bootstrap ==' -ForegroundColor Cyan
@@ -96,6 +94,10 @@ Write-Host '== AssetGuard Extraction Tool Bootstrap ==' -ForegroundColor Cyan
 if (-not (Test-Path '.\.venv\Scripts\Activate.ps1') -and -not (Test-Path '.\venv\Scripts\Activate.ps1')) {
     Write-Host '[First-time] No extraction-tool virtual environment found. Creating .venv ...' -ForegroundColor Yellow
     python -m venv .venv
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host '[Extraction skipped] Failed to create venv (.venv).' -ForegroundColor Yellow
+        return
+    }
 }
 
 if (Test-Path '.\.venv\Scripts\Activate.ps1') {
@@ -107,14 +109,24 @@ if (Test-Path '.\.venv\Scripts\Activate.ps1') {
 }
 
 if (-not (Test-Path $pyExe)) {
-    throw "Python executable not found in venv: $pyExe"
+    Write-Host '[Extraction skipped] Python executable not found in venv: ' $pyExe -ForegroundColor Yellow
+    return
 }
 
 Write-Host 'Python executable path:' (Resolve-Path $pyExe) -ForegroundColor Green
+
 & $pyExe -m pip install --upgrade pip
+if ($LASTEXITCODE -ne 0) {
+    Write-Host '[Extraction skipped] pip upgrade failed.' -ForegroundColor Yellow
+    return
+}
 
 Write-Host 'Ensuring extraction-tool dependencies from requirements.txt ...' -ForegroundColor Cyan
 & $pyExe -m pip install -r requirements.txt
+if ($LASTEXITCODE -ne 0) {
+    Write-Host '[Extraction skipped] pip install -r requirements.txt failed.' -ForegroundColor Yellow
+    return
+}
 
 if (-not (Test-Path '.\.env')) {
     Write-Host '[Warning] .env file not found in extraction tool folder. Some features may not work.' -ForegroundColor Yellow
@@ -123,6 +135,10 @@ if (-not (Test-Path '.\.env')) {
 Write-Host 'Starting extraction tool server on http://127.0.0.1:5001 ...' -ForegroundColor Cyan
 $env:FLASK_RUN_PORT = '5001'
 & $pyExe -m flask --app app.py run --port 5001
+}
+catch {
+    Write-Host '[Extraction skipped] Error during extraction tool startup:' $_.Exception.Message -ForegroundColor Yellow
+}
 '@
 
 $backendCmd = $backendCmdTemplate.Replace("__BACKEND_DIR__", $backendDir)
@@ -143,15 +159,22 @@ Start-Process powershell -ArgumentList @(
     "`$Host.UI.RawUI.WindowTitle='AssetGuard Frontend'; $frontendCmd"
 )
 
+Write-Host "Started backend and frontend in two new PowerShell windows."
+
 Start-Sleep -Milliseconds 500
 
-Start-Process powershell -ArgumentList @(
-    "-NoExit",
-    "-Command",
-    "`$Host.UI.RawUI.WindowTitle='AssetGuard Extraction Tool'; $extractionCmd"
-)
-
-Write-Host "Started backend, frontend, and extraction tool in three new PowerShell windows."
-Write-Host "  Backend:        http://127.0.0.1:5000"
-Write-Host "  Frontend:       (see frontend window for Vite URL)"
-Write-Host "  Extraction:     http://127.0.0.1:5001"
+if (Test-Path $extractionDir) {
+    Start-Process powershell -ArgumentList @(
+        "-NoExit",
+        "-Command",
+        "`$Host.UI.RawUI.WindowTitle='AssetGuard Extraction Tool'; $extractionCmd"
+    )
+    Write-Host "Also started extraction tool in a separate window."
+    Write-Host "  Backend:        http://127.0.0.1:5000"
+    Write-Host "  Frontend:       (see frontend window for Vite URL)"
+    Write-Host "  Extraction:     http://127.0.0.1:5001"
+} else {
+    Write-Host "[Warning] Extraction tool folder not found; skipping extraction server: $extractionDir" -ForegroundColor Yellow
+    Write-Host "  Backend:        http://127.0.0.1:5000"
+    Write-Host "  Frontend:       (see frontend window for Vite URL)"
+}

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -3,6 +3,7 @@ $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $backendDir = Join-Path $repoRoot "AssetGuard-AI"
 $frontendDir = Join-Path $repoRoot "assetguard-ui"
+$extractionDir = Join-Path $repoRoot "gjp-assetguard-extraction-tool"
 
 if (-not (Test-Path $backendDir)) {
     throw "Backend folder not found: $backendDir"
@@ -10,6 +11,10 @@ if (-not (Test-Path $backendDir)) {
 
 if (-not (Test-Path $frontendDir)) {
     throw "Frontend folder not found: $frontendDir"
+}
+
+if (-not (Test-Path $extractionDir)) {
+    throw "Extraction tool folder not found: $extractionDir"
 }
 
 $backendCmdTemplate = @'
@@ -83,8 +88,46 @@ Write-Host 'Starting frontend dev server ...' -ForegroundColor Cyan
 npm run dev
 '@
 
+$extractionCmdTemplate = @'
+Set-Location '__EXTRACTION_DIR__'
+
+Write-Host '== AssetGuard Extraction Tool Bootstrap ==' -ForegroundColor Cyan
+
+if (-not (Test-Path '.\.venv\Scripts\Activate.ps1') -and -not (Test-Path '.\venv\Scripts\Activate.ps1')) {
+    Write-Host '[First-time] No extraction-tool virtual environment found. Creating .venv ...' -ForegroundColor Yellow
+    python -m venv .venv
+}
+
+if (Test-Path '.\.venv\Scripts\Activate.ps1') {
+    $pyExe = '.\.venv\Scripts\python.exe'
+    Write-Host 'Using extraction-tool venv: .venv' -ForegroundColor Green
+} else {
+    $pyExe = '.\venv\Scripts\python.exe'
+    Write-Host 'Using extraction-tool venv: venv' -ForegroundColor Green
+}
+
+if (-not (Test-Path $pyExe)) {
+    throw "Python executable not found in venv: $pyExe"
+}
+
+Write-Host 'Python executable path:' (Resolve-Path $pyExe) -ForegroundColor Green
+& $pyExe -m pip install --upgrade pip
+
+Write-Host 'Ensuring extraction-tool dependencies from requirements.txt ...' -ForegroundColor Cyan
+& $pyExe -m pip install -r requirements.txt
+
+if (-not (Test-Path '.\.env')) {
+    Write-Host '[Warning] .env file not found in extraction tool folder. Some features may not work.' -ForegroundColor Yellow
+}
+
+Write-Host 'Starting extraction tool server on http://127.0.0.1:5001 ...' -ForegroundColor Cyan
+$env:FLASK_RUN_PORT = '5001'
+& $pyExe -m flask --app app.py run --port 5001
+'@
+
 $backendCmd = $backendCmdTemplate.Replace("__BACKEND_DIR__", $backendDir)
 $frontendCmd = $frontendCmdTemplate.Replace("__FRONTEND_DIR__", $frontendDir)
+$extractionCmd = $extractionCmdTemplate.Replace("__EXTRACTION_DIR__", $extractionDir)
 
 Start-Process powershell -ArgumentList @(
     "-NoExit",
@@ -100,4 +143,15 @@ Start-Process powershell -ArgumentList @(
     "`$Host.UI.RawUI.WindowTitle='AssetGuard Frontend'; $frontendCmd"
 )
 
-Write-Host "Started backend and frontend in two new PowerShell windows."
+Start-Sleep -Milliseconds 500
+
+Start-Process powershell -ArgumentList @(
+    "-NoExit",
+    "-Command",
+    "`$Host.UI.RawUI.WindowTitle='AssetGuard Extraction Tool'; $extractionCmd"
+)
+
+Write-Host "Started backend, frontend, and extraction tool in three new PowerShell windows."
+Write-Host "  Backend:        http://127.0.0.1:5000"
+Write-Host "  Frontend:       (see frontend window for Vite URL)"
+Write-Host "  Extraction:     http://127.0.0.1:5001"

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -18,11 +18,6 @@ if [[ ! -d "$FRONTEND_DIR" ]]; then
   exit 1
 fi
 
-if [[ ! -d "$EXTRACTION_DIR" ]]; then
-  echo "Extraction tool folder not found: $EXTRACTION_DIR" >&2
-  exit 1
-fi
-
 # ─── Backend bootstrap ────────────────────────────────────────────────────────
 echo "== AssetGuard Backend Bootstrap =="
 cd "$BACKEND_DIR"
@@ -88,35 +83,8 @@ else
   echo "[Normal] node_modules exists. Skip npm install."
 fi
 
-# ─── Extraction tool bootstrap ────────────────────────────────────────────────
-echo "== AssetGuard Extraction Tool Bootstrap =="
-cd "$EXTRACTION_DIR"
-
-if [[ ! -x ".venv/bin/python" && ! -x "venv/bin/python" ]]; then
-  echo "[First-time] No extraction-tool virtual environment found. Creating .venv ..."
-  python3 -m venv .venv
-fi
-
-if [[ -x ".venv/bin/python" ]]; then
-  EXTRACTION_PY=".venv/bin/python"
-  echo "Using extraction-tool venv: .venv"
-else
-  EXTRACTION_PY="venv/bin/python"
-  echo "Using extraction-tool venv: venv"
-fi
-
-echo "Python executable path: $EXTRACTION_DIR/$EXTRACTION_PY"
-"$EXTRACTION_PY" -m pip install --upgrade pip
-
-echo "Ensuring extraction-tool dependencies from requirements.txt ..."
-"$EXTRACTION_PY" -m pip install -r requirements.txt
-
-if [[ ! -f ".env" ]]; then
-  echo "[Warning] .env file not found in extraction tool folder. Some features may not work."
-fi
-
-# ─── Start all three servers ──────────────────────────────────────────────────
-echo "Starting backend, frontend, and extraction tool dev servers ..."
+# ─── Start backend + frontend first (extraction failures must not block these) ─
+echo "Starting backend and frontend dev servers ..."
 
 cd "$BACKEND_DIR"
 "$BACKEND_PY" -m flask --app assetguard_app.py run &
@@ -126,22 +94,85 @@ cd "$FRONTEND_DIR"
 npm run dev &
 FRONTEND_PID=$!
 
-cd "$EXTRACTION_DIR"
-"$EXTRACTION_PY" -m flask --app app.py run --port 5001 &
-EXTRACTION_PID=$!
+EXTRACTION_PID=""
+if [[ -d "$EXTRACTION_DIR" ]]; then
+  (
+    set +e
+    set +u
+    cd "$EXTRACTION_DIR" || {
+      echo "[Warning] Extraction tool: could not cd to $EXTRACTION_DIR. Skipping." >&2
+      exit 0
+    }
+
+    echo "== AssetGuard Extraction Tool Bootstrap =="
+
+    if [[ ! -x ".venv/bin/python" && ! -x "venv/bin/python" ]]; then
+      echo "[First-time] No extraction-tool virtual environment found. Creating .venv ..."
+      if ! python3 -m venv .venv; then
+        echo "[Warning] Extraction tool: venv creation failed. Skipping extraction server." >&2
+        exit 0
+      fi
+    fi
+
+    if [[ -x ".venv/bin/python" ]]; then
+      EXTRACTION_PY=".venv/bin/python"
+      echo "Using extraction-tool venv: .venv"
+    else
+      EXTRACTION_PY="venv/bin/python"
+      echo "Using extraction-tool venv: venv"
+    fi
+
+    if [[ ! -x "$EXTRACTION_PY" ]]; then
+      echo "[Warning] Extraction tool: Python not found at $EXTRACTION_PY. Skipping." >&2
+      exit 0
+    fi
+
+    echo "Python executable path: $EXTRACTION_DIR/$EXTRACTION_PY"
+    if ! "$EXTRACTION_PY" -m pip install --upgrade pip; then
+      echo "[Warning] Extraction tool: pip upgrade failed. Skipping extraction server." >&2
+      exit 0
+    fi
+
+    echo "Ensuring extraction-tool dependencies from requirements.txt ..."
+    if ! "$EXTRACTION_PY" -m pip install -r requirements.txt; then
+      echo "[Warning] Extraction tool: pip install failed. Skipping extraction server." >&2
+      exit 0
+    fi
+
+    if [[ ! -f ".env" ]]; then
+      echo "[Warning] .env file not found in extraction tool folder. Some features may not work."
+    fi
+
+    echo "Starting extraction tool server on http://127.0.0.1:5001 ..."
+    exec "$EXTRACTION_PY" -m flask --app app.py run --port 5001
+  ) &
+  EXTRACTION_PID=$!
+else
+  echo "[Warning] Extraction tool folder not found; skipping extraction server: $EXTRACTION_DIR" >&2
+fi
 
 echo ""
 echo "Services started:"
 echo "  Backend         (pid=$BACKEND_PID)    http://127.0.0.1:5000"
 echo "  Frontend        (pid=$FRONTEND_PID)   (see frontend output for Vite URL)"
-echo "  Extraction Tool (pid=$EXTRACTION_PID) http://127.0.0.1:5001"
+if [[ -n "$EXTRACTION_PID" ]]; then
+  echo "  Extraction Tool (pid=$EXTRACTION_PID) http://127.0.0.1:5001"
+else
+  echo "  Extraction Tool (not started)"
+fi
 echo ""
 
 cleanup() {
   echo ""
-  echo "Stopping backend, frontend, and extraction tool..."
-  kill "$BACKEND_PID" "$FRONTEND_PID" "$EXTRACTION_PID" 2>/dev/null || true
+  echo "Stopping dev servers..."
+  kill "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+  if [[ -n "${EXTRACTION_PID:-}" ]]; then
+    kill "$EXTRACTION_PID" 2>/dev/null || true
+  fi
 }
 
 trap cleanup INT TERM
-wait "$BACKEND_PID" "$FRONTEND_PID" "$EXTRACTION_PID"
+wait "$BACKEND_PID" "$FRONTEND_PID"
+if [[ -n "${EXTRACTION_PID:-}" ]]; then
+  wait "$EXTRACTION_PID" || true
+fi

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR"
 BACKEND_DIR="$REPO_ROOT/AssetGuard-AI"
 FRONTEND_DIR="$REPO_ROOT/assetguard-ui"
+EXTRACTION_DIR="$REPO_ROOT/gjp-assetguard-extraction-tool"
 
 if [[ ! -d "$BACKEND_DIR" ]]; then
   echo "Backend folder not found: $BACKEND_DIR" >&2
@@ -17,6 +18,12 @@ if [[ ! -d "$FRONTEND_DIR" ]]; then
   exit 1
 fi
 
+if [[ ! -d "$EXTRACTION_DIR" ]]; then
+  echo "Extraction tool folder not found: $EXTRACTION_DIR" >&2
+  exit 1
+fi
+
+# ─── Backend bootstrap ────────────────────────────────────────────────────────
 echo "== AssetGuard Backend Bootstrap =="
 cd "$BACKEND_DIR"
 
@@ -26,18 +33,18 @@ if [[ ! -x ".venv/bin/python" && ! -x "venv/bin/python" ]]; then
 fi
 
 if [[ -x ".venv/bin/python" ]]; then
-  PY_EXE=".venv/bin/python"
+  BACKEND_PY=".venv/bin/python"
   echo "Using backend venv: .venv"
 else
-  PY_EXE="venv/bin/python"
+  BACKEND_PY="venv/bin/python"
   echo "Using backend venv: venv"
 fi
 
-echo "Python executable path: $BACKEND_DIR/$PY_EXE"
-"$PY_EXE" -m pip install --upgrade pip
+echo "Python executable path: $BACKEND_DIR/$BACKEND_PY"
+"$BACKEND_PY" -m pip install --upgrade pip
 
 echo "Ensuring backend dependencies from requirements.txt ..."
-"$PY_EXE" -m pip install -r requirements.txt
+"$BACKEND_PY" -m pip install -r requirements.txt
 
 BOOTSTRAP_MARKER=".dev_bootstrap_done"
 DB_PATH="./instance/assetguard.db"
@@ -54,7 +61,7 @@ else
 fi
 
 echo "Running database migrations: flask db upgrade ..."
-"$PY_EXE" -m flask --app assetguard_app.py db upgrade
+"$BACKEND_PY" -m flask --app assetguard_app.py db upgrade
 
 if [[ "$MARKER_EXISTS" == false || "$DB_EXISTED_BEFORE_UPGRADE" == false ]]; then
   if [[ "$DB_EXISTED_BEFORE_UPGRADE" == false ]]; then
@@ -63,13 +70,14 @@ if [[ "$MARKER_EXISTS" == false || "$DB_EXISTED_BEFORE_UPGRADE" == false ]]; the
     echo "[First-time] Bootstrap marker missing. Running flask seed ..."
   fi
 
-  "$PY_EXE" -m flask --app assetguard_app.py seed
+  "$BACKEND_PY" -m flask --app assetguard_app.py seed
   touch "$BOOTSTRAP_MARKER"
   echo "[First-time] Bootstrap completed. Marker file created."
 else
   echo "[Normal] Bootstrap marker found and database existed before startup. Skip flask seed."
 fi
 
+# ─── Frontend bootstrap ───────────────────────────────────────────────────────
 echo "== AssetGuard Frontend Bootstrap =="
 cd "$FRONTEND_DIR"
 
@@ -80,21 +88,60 @@ else
   echo "[Normal] node_modules exists. Skip npm install."
 fi
 
-echo "Starting backend and frontend dev servers ..."
+# ─── Extraction tool bootstrap ────────────────────────────────────────────────
+echo "== AssetGuard Extraction Tool Bootstrap =="
+cd "$EXTRACTION_DIR"
+
+if [[ ! -x ".venv/bin/python" && ! -x "venv/bin/python" ]]; then
+  echo "[First-time] No extraction-tool virtual environment found. Creating .venv ..."
+  python3 -m venv .venv
+fi
+
+if [[ -x ".venv/bin/python" ]]; then
+  EXTRACTION_PY=".venv/bin/python"
+  echo "Using extraction-tool venv: .venv"
+else
+  EXTRACTION_PY="venv/bin/python"
+  echo "Using extraction-tool venv: venv"
+fi
+
+echo "Python executable path: $EXTRACTION_DIR/$EXTRACTION_PY"
+"$EXTRACTION_PY" -m pip install --upgrade pip
+
+echo "Ensuring extraction-tool dependencies from requirements.txt ..."
+"$EXTRACTION_PY" -m pip install -r requirements.txt
+
+if [[ ! -f ".env" ]]; then
+  echo "[Warning] .env file not found in extraction tool folder. Some features may not work."
+fi
+
+# ─── Start all three servers ──────────────────────────────────────────────────
+echo "Starting backend, frontend, and extraction tool dev servers ..."
 
 cd "$BACKEND_DIR"
-"$PY_EXE" -m flask --app assetguard_app.py run &
+"$BACKEND_PY" -m flask --app assetguard_app.py run &
 BACKEND_PID=$!
 
 cd "$FRONTEND_DIR"
 npm run dev &
 FRONTEND_PID=$!
 
+cd "$EXTRACTION_DIR"
+"$EXTRACTION_PY" -m flask --app app.py run --port 5001 &
+EXTRACTION_PID=$!
+
+echo ""
+echo "Services started:"
+echo "  Backend         (pid=$BACKEND_PID)    http://127.0.0.1:5000"
+echo "  Frontend        (pid=$FRONTEND_PID)   (see frontend output for Vite URL)"
+echo "  Extraction Tool (pid=$EXTRACTION_PID) http://127.0.0.1:5001"
+echo ""
+
 cleanup() {
   echo ""
-  echo "Stopping backend and frontend..."
-  kill "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+  echo "Stopping backend, frontend, and extraction tool..."
+  kill "$BACKEND_PID" "$FRONTEND_PID" "$EXTRACTION_PID" 2>/dev/null || true
 }
 
 trap cleanup INT TERM
-wait "$BACKEND_PID" "$FRONTEND_PID"
+wait "$BACKEND_PID" "$FRONTEND_PID" "$EXTRACTION_PID"


### PR DESCRIPTION
Update Windows and Unix startup scripts to bootstrap and run three services together: AssetGuard backend, assetguard-ui frontend, and the gjp extraction tool.

Add extraction environment checks, dependency install steps, and start the extraction server on port 5001 to avoid backend port conflicts.