### PR TITLE
feat: add user-specific evaluation history endpoint

### DIFF
--- a/AssetGuard-AI/API_DOCUMENTATION.md
+++ b/AssetGuard-AI/API_DOCUMENTATION.md
@@ -1240,6 +1240,69 @@ List all past evaluation log entries, most recent first.
 
 ---
 
+### GET `/api/v1/evaluations/history/user/<user_id>`
+
+List evaluation log entries for a specific user, most recent first. Supports the same filters and pagination as the general history endpoint.
+
+**Permissions:** `System_Admin`, `Asset_Manager`.
+
+**Path parameters:**
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `user_id` | integer | Yes | ID of the user whose evaluation logs to retrieve |
+
+**Query parameters:**
+
+| Parameter | Type | Required | Default | Notes |
+|-----------|------|----------|---------|-------|
+| `page` | integer | No | `1` | Must be ≥ 1 |
+| `pageSize` | integer | No | `20` | Must be 1–200 |
+| `assetId` | integer | No | — | Filter by asset ID |
+| `equipment` | string | No | — | Filter by exact equipment type name |
+| `status` | string | No | — | Filter by `"Compliant"` or `"Non-Compliant"` |
+| `fromDate` | string | No | — | Filter records on or after this date (format: `YYYY-MM-DD`) |
+| `toDate` | string | No | — | Filter records before this date (format: `YYYY-MM-DD`) |
+
+**Response `200`:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [
+      {
+        "id": 7,
+        "assetId": 10,
+        "assetName": "Berth 5 Deck",
+        "equipment": "Crane with outriggers",
+        "equipmentModel": "LTM 1100",
+        "loadParameterValue": 500.0,
+        "loadParameterMetric": "kN",
+        "matchedCapacityName": "max point load",
+        "status": "Compliant",
+        "overloadPercentage": 0.0,
+        "remark": "Pre-lift check",
+        "evaluatedAt": "2026-03-24T12:34:56+08:00"
+      }
+    ],
+    "page": 1,
+    "pageSize": 20,
+    "total": 1,
+    "pages": 1
+  }
+}
+```
+
+**Possible errors:**
+
+| Status | Code | Description |
+|--------|------|-------------|
+| `400` | `validation_error` | Pagination parameters out of range, invalid date format, or invalid status value |
+| `403` | — | Caller is `Contractors` (insufficient permission) |
+
+---
+
 ### GET `/api/v1/evaluations/dashboard-summary`
 
 Return aggregated evaluation statistics for the dashboard, including totals, overload stats, equipment breakdown, top assets, and recent evaluations.

--- a/AssetGuard-AI/app/controllers/evaluation_controller.py
+++ b/AssetGuard-AI/app/controllers/evaluation_controller.py
@@ -115,6 +115,34 @@ def history():
     return ok(data)
 
 
+@evaluations_bp.get("/history/user/<int:user_id>")
+@require_roles(UserRole.SYSTEM_ADMIN.value, UserRole.ASSET_MANAGER.value)
+def history_by_user(user_id: int):
+    _ = get_auth_context()
+    page = int(request.args.get("page", 1))
+    page_size = int(request.args.get("pageSize", 20))
+    if page < 1 or page_size < 1 or page_size > 200:
+        raise ApiError("Invalid pagination parameters", 400, code="validation_error")
+
+    asset_id = request.args.get("assetId", type=int)
+    equipment = request.args.get("equipment")
+    status = request.args.get("status")
+    from_date = _parse_optional_date(request.args.get("fromDate"))
+    to_date = _parse_optional_date(request.args.get("toDate"))
+
+    data = EvaluationService.history(
+        page=page,
+        page_size=page_size,
+        asset_id=asset_id,
+        user_id=user_id,
+        equipment=equipment,
+        status=status,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    return ok(data)
+
+
 @evaluations_bp.get("/dashboard-summary")
 @require_roles(UserRole.SYSTEM_ADMIN.value, UserRole.ASSET_MANAGER.value)
 def dashboard_summary():

--- a/AssetGuard-AI/app/services/evaluation_service.py
+++ b/AssetGuard-AI/app/services/evaluation_service.py
@@ -122,6 +122,7 @@ class EvaluationService:
         page: int,
         page_size: int,
         asset_id: int | None = None,
+        user_id: int | None = None,
         equipment: str | None = None,
         status: str | None = None,
         from_date: date | None = None,
@@ -131,6 +132,8 @@ class EvaluationService:
 
         if asset_id is not None:
             stmt = stmt.where(EvaluationLog.asset_id == asset_id)
+        if user_id is not None:
+            stmt = stmt.where(EvaluationLog.user_id == user_id)
         if equipment is not None:
             stmt = stmt.where(EvaluationLog.equipment == equipment)
         if status is not None:


### PR DESCRIPTION
## Summary

Add a new API endpoint to query evaluation logs filtered by user ID, enabling per-user evaluation history views in the frontend.

## Changes

- **New endpoint** `GET /api/v1/evaluations/history/user/<user_id>` — filters evaluation logs by user ID, supports the same pagination and query parameters as `/evaluations/history` (assetId, equipment, status, fromDate, toDate)
- **Service layer** `EvaluationService.history()` gains an optional `user_id` parameter — fully backward compatible, does not affect existing callers
- **Docs** updated in `API_DOCUMENTATION.md`

## Files changed

| File | Change |
|------|--------|
| `app/services/evaluation_service.py` | Added optional `user_id` param and corresponding WHERE filter in `history()` |
| `app/controllers/evaluation_controller.py` | Added `history_by_user` route |
| `API_DOCUMENTATION.md` | Added endpoint documentation |

## Permissions

`System_Admin`, `Asset_Manager` (same as the existing `/evaluations/history`)

## Test plan

- [x] All 4 existing tests pass (`python -m pytest tests/ -v`)
- [x] Manual: `GET /api/v1/evaluations/history/user/1` returns evaluation logs for user 1
- [x] Manual: `GET /api/v1/evaluations/history/user/1?status=Non-Compliant` returns only non-compliant logs for user 1
- [x] Verify existing `/api/v1/evaluations/history` behavior is unchanged